### PR TITLE
remove extraneous argument to use_ok

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -8,7 +8,7 @@ BEGIN { use_ok('D64::Disk::Dir', qw(:all)) };
 }
 #########################
 {
-BEGIN { use_ok('D64::Disk::Dir::Entry', qw(:all)) };
+BEGIN { use_ok('D64::Disk::Dir::Entry') };
 }
 #########################
 {

--- a/t/03-entry.t
+++ b/t/03-entry.t
@@ -9,7 +9,7 @@ use D64::Disk::Image qw(:all);
 use File::Temp qw(tmpnam);
 #########################
 {
-BEGIN { use_ok('D64::Disk::Dir::Entry', qw(:all)) };
+BEGIN { use_ok('D64::Disk::Dir::Entry') };
 }
 #########################
 # Helper subroutine to create image and populate it with files for directory entry access method test cases:


### PR DESCRIPTION
D64::Disk::Dir::Entry does not export anything, so passing arguments to its import methods is pointless. Future versions are intending to make it an error to pass arguments to an undefined import method.